### PR TITLE
When a player clicks with a currency item with a mismatched faction name, the lore will be updated to reflect the new name.

### DIFF
--- a/src/main/java/dansplugins/currencies/CurrencyFactory.java
+++ b/src/main/java/dansplugins/currencies/CurrencyFactory.java
@@ -35,8 +35,6 @@ public class CurrencyFactory {
             return null;
         }
 
-        String name = currency.getName();
-
         meta.setDisplayName(currency.getName());
         meta.setLore(asList(
             "",

--- a/src/main/java/dansplugins/currencies/EventRegistry.java
+++ b/src/main/java/dansplugins/currencies/EventRegistry.java
@@ -1,8 +1,5 @@
 package dansplugins.currencies;
-import dansplugins.currencies.eventhandlers.CraftingHandler;
-import dansplugins.currencies.eventhandlers.FactionEventHandler;
-import dansplugins.currencies.eventhandlers.JoinHandler;
-import dansplugins.currencies.eventhandlers.PlacementHandler;
+import dansplugins.currencies.eventhandlers.*;
 import org.bukkit.plugin.PluginManager;
 
 public class EventRegistry {
@@ -30,5 +27,6 @@ public class EventRegistry {
         manager.registerEvents(new CraftingHandler(), mainInstance);
         manager.registerEvents(new PlacementHandler(), mainInstance);
         manager.registerEvents(new FactionEventHandler(), mainInstance);
+        manager.registerEvents(new InteractionHandler(), mainInstance);
     }
 }

--- a/src/main/java/dansplugins/currencies/eventhandlers/InteractionHandler.java
+++ b/src/main/java/dansplugins/currencies/eventhandlers/InteractionHandler.java
@@ -1,6 +1,7 @@
 package dansplugins.currencies.eventhandlers;
 
 import dansplugins.currencies.Currencies;
+import dansplugins.currencies.CurrencyFactory;
 import dansplugins.currencies.MedievalFactionsIntegrator;
 import dansplugins.currencies.data.PersistentData;
 import dansplugins.currencies.managers.CurrencyManager;
@@ -12,17 +13,10 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.List;
-
 public class InteractionHandler implements Listener {
 
     @EventHandler()
     public void handle(PlayerInteractEvent event) {
-
-        MF_Faction faction = MedievalFactionsIntegrator.getInstance().getAPI().getFaction(event.getPlayer());
-        if (faction == null) {
-            return;
-        }
 
         ItemStack itemStack = event.getPlayer().getInventory().getItemInMainHand();
         ItemMeta meta = itemStack.getItemMeta();
@@ -30,13 +24,17 @@ public class InteractionHandler implements Listener {
             return;
         }
 
-        int currencyID = Integer.parseInt(CurrencyManager.getInstance().getCurrencyIDFromLore(meta));
+        String factionName = CurrencyManager.getInstance().getFactionName(meta);
+        int currencyID = Integer.parseInt(CurrencyManager.getInstance().getCurrencyID(meta));
 
         Currency currency = PersistentData.getInstance().getCurrency(currencyID);
+        if (currency == null) {
+            return;
+        }
 
-        if (!currency.getFactionName().equalsIgnoreCase(faction.getName())) {
-            currency.setFactionName(faction.getName());
+        if (!currency.getFactionName().equalsIgnoreCase(factionName)) {
             if (Currencies.getInstance().isDebugEnabled()) { System.out.println("[DEBUG] Fixing faction name mismatch with an item stack."); }
+            event.getPlayer().getInventory().setItemInMainHand(CurrencyFactory.getInstance().createCurrencyItem(currency, itemStack.getAmount()));
         }
     }
 

--- a/src/main/java/dansplugins/currencies/eventhandlers/InteractionHandler.java
+++ b/src/main/java/dansplugins/currencies/eventhandlers/InteractionHandler.java
@@ -1,0 +1,43 @@
+package dansplugins.currencies.eventhandlers;
+
+import dansplugins.currencies.Currencies;
+import dansplugins.currencies.MedievalFactionsIntegrator;
+import dansplugins.currencies.data.PersistentData;
+import dansplugins.currencies.managers.CurrencyManager;
+import dansplugins.currencies.objects.Currency;
+import dansplugins.factionsystem.externalapi.MF_Faction;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+public class InteractionHandler implements Listener {
+
+    @EventHandler()
+    public void handle(PlayerInteractEvent event) {
+
+        MF_Faction faction = MedievalFactionsIntegrator.getInstance().getAPI().getFaction(event.getPlayer());
+        if (faction == null) {
+            return;
+        }
+
+        ItemStack itemStack = event.getPlayer().getInventory().getItemInMainHand();
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+
+        int currencyID = Integer.parseInt(CurrencyManager.getInstance().getCurrencyIDFromLore(meta));
+
+        Currency currency = PersistentData.getInstance().getCurrency(currencyID);
+
+        if (!currency.getFactionName().equalsIgnoreCase(faction.getName())) {
+            currency.setFactionName(faction.getName());
+            if (Currencies.getInstance().isDebugEnabled()) { System.out.println("[DEBUG] Fixing faction name mismatch with an item stack."); }
+        }
+    }
+
+}

--- a/src/main/java/dansplugins/currencies/managers/CurrencyManager.java
+++ b/src/main/java/dansplugins/currencies/managers/CurrencyManager.java
@@ -57,7 +57,11 @@ public class CurrencyManager {
         return isCurrencyIDTaken(currencyID);
     }
 
-    private String getCurrencyIDFromLore(ItemMeta meta) {
+    public void updateCurrencyIfNecessary(ItemStack itemStack) {
+        // TODO: implement
+    }
+
+    public String getCurrencyIDFromLore(ItemMeta meta) {
         List<String> lore = meta.getLore();
         if (lore == null) {
             return null;

--- a/src/main/java/dansplugins/currencies/managers/CurrencyManager.java
+++ b/src/main/java/dansplugins/currencies/managers/CurrencyManager.java
@@ -4,6 +4,7 @@ import dansplugins.currencies.Currencies;
 import dansplugins.currencies.data.PersistentData;
 import dansplugins.currencies.objects.Currency;
 import dansplugins.factionsystem.externalapi.MF_Faction;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -47,7 +48,7 @@ public class CurrencyManager {
             return false;
         }
 
-        String currencyIDString = getCurrencyIDFromLore(itemMeta);
+        String currencyIDString = getCurrencyID(itemMeta);
         if (currencyIDString == null) {
             return false;
         }
@@ -57,11 +58,23 @@ public class CurrencyManager {
         return isCurrencyIDTaken(currencyID);
     }
 
-    public void updateCurrencyIfNecessary(ItemStack itemStack) {
-        // TODO: implement
+    public String getFactionName(ItemMeta meta) {
+        List<String> lore = meta.getLore();
+        if (lore == null) {
+            return null;
+        }
+        for (String s : lore) {
+            if (s.contains("faction")) {
+                String factionName = s.substring(14);
+                if (Currencies.getInstance().isDebugEnabled()) {
+                    return factionName;
+                }
+            }
+        }
+        return null;
     }
 
-    public String getCurrencyIDFromLore(ItemMeta meta) {
+    public String getCurrencyID(ItemMeta meta) {
         List<String> lore = meta.getLore();
         if (lore == null) {
             return null;
@@ -70,7 +83,6 @@ public class CurrencyManager {
             if (s.contains("currencyID")) {
                 String ID = s.substring(14);
                 if (Currencies.getInstance().isDebugEnabled()) {
-                    System.out.println("Currency ID found: " + ID);
                     return ID;
                 }
             }


### PR DESCRIPTION
closes #34 