### PR TITLE
Fix duplicate currency name check when using --rename flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed `/currency create` with `--rename`/`--no-rename` failing with a database constraint error when a currency with that name already existed, because the duplicate-name check compared against the raw arguments (including the flag) instead of the parsed currency name
+
 ## [2.1.0]
 
 ### Changed

--- a/src/main/kotlin/com/dansplugins/currencies/command/currency/create/CurrencyCreateCommand.kt
+++ b/src/main/kotlin/com/dansplugins/currencies/command/currency/create/CurrencyCreateCommand.kt
@@ -93,7 +93,7 @@ class CurrencyCreateCommand(private val plugin: Currencies) : CommandExecutor, T
                 return@Runnable
             }
             val currencyService = plugin.services.currencyService
-            val existingCurrency = currencyService.getCurrency(args.joinToString(" "))
+            val existingCurrency = currencyService.getCurrency(currencyName)
             if (existingCurrency != null) {
                 sender.sendMessage("${RED}There is already a currency with that name.")
                 return@Runnable


### PR DESCRIPTION
## Summary
- Fixes the duplicate-currency-name check in `/currency create` to compare against the parsed currency name instead of the raw command arguments, so it correctly detects an existing currency even when `--rename`/`--no-rename` flags are present.
- Documents the fix in `CHANGELOG.md` under `[Unreleased] > Fixed`.

## Why
`CurrencyCreateCommand.kt` computes `currencyName` by filtering out the `--rename`/`--no-rename` flags from `args`, but the duplicate-name lookup used the raw `args.joinToString(" ")` (flags included). This mismatch meant the lookup for `"SantiagoReal --rename"` never matched the existing `"SantiagoReal"` currency, so the duplicate check silently passed and the save hit the database's unique constraint on `currencies_currency.name`, producing an unhandled SQL 23505 error instead of the intended "There is already a currency with that name." message.

This carries forward the fix from draft PR #195 (opened by the Copilot coding agent), rebased onto current `main` and made mergeable — see note below.

## Test plan
- [x] `./gradlew compileKotlin` — passes
- [x] `./gradlew test` — passes (no automated test suite exists in this repo yet; this is a one-line logic fix inside a Bukkit-coupled command handler with no isolated pure function to unit test without a larger refactor, which is out of scope here)
- [x] Manually traced the code path: `currencyName` (flags filtered) is now used consistently for both the display-name comparison and the duplicate-name check

Closes #191

---
Note: PR #195 contains the same fix but is stuck in Draft state and can't be converted to "Ready for review" or merged by this automation (both `gh pr ready` and the GraphQL API needed to un-draft it are outside this run's tool allow-list). This PR carries the same change forward on a fresh, non-draft branch rebased onto current `main`. #195 will be closed with a pointer to this PR.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
