### PR TITLE
Correct documentation drift and add attribution for alyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added attribution for alyphen to the developers table in `README.md`
 
 ### Changed
-- Corrected documentation drift found by verifying `COMMANDS.md`, `CONFIG.md`, and `USER_GUIDE.md` against the command and listener sources: `/currency create` now documents its held-item requirement and `--rename`/`--no-rename` flags, `/currency list` documents its `all`/`retired`/faction filters and pagination, `/currency mint` documents that the amount is optional, `/currency retire` documents its `confirm` argument, `/currency set name` and `/currency set description` document their chat prompts, `currencies.showAmountMinted` is described as controlling the `Minted:` line in `/currency info`, `currencies.powerCost` is documented as a decimal charged per coin, and the power cost is described as the minting player's power rather than faction power
+- Documented that `/currency create` uses the item held in the main hand and accepts `--rename`/`--no-rename` to answer its rename prompt up front
+- Corrected `/currency list`, which lists every active currency on the server rather than only the caller's faction's, and documented its `all`/`retired`/faction filters and page argument
+- Documented that the amount argument of `/currency mint` is optional and defaults to `1`
+- Documented the `confirm` argument of `/currency retire` and the confirmation prompt shown without it
+- Documented that `/currency set name` and `/currency set description` fall back to a chat prompt when the new value is omitted
+- Corrected the description of `currencies.showAmountMinted`, which controls the `Minted:` line in `/currency info` rather than a message shown after minting
+- Corrected `currencies.powerCost`, which is a decimal charged per coin minted rather than an integer charged per mint operation
+- Corrected the power cost wording throughout, since the cost is deducted from the minting player's power rather than faction power
+- Corrected the description of `currencies.itemCostEnabled`, which consumes the currency's own item type per coin rather than a cost configured per currency
 
 ### Removed
 - Removed Currencies 1 migration code (`legacy` package and the associated startup migration checks), since servers now run exclusively on Currencies 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Added attribution for alyphen to the developers table in `README.md`
+
+### Changed
+- Corrected documentation drift found by verifying `COMMANDS.md`, `CONFIG.md`, and `USER_GUIDE.md` against the command and listener sources: `/currency create` now documents its held-item requirement and `--rename`/`--no-rename` flags, `/currency list` documents its `all`/`retired`/faction filters and pagination, `/currency mint` documents that the amount is optional, `/currency retire` documents its `confirm` argument, `/currency set name` and `/currency set description` document their chat prompts, `currencies.showAmountMinted` is described as controlling the `Minted:` line in `/currency info`, `currencies.powerCost` is documented as a decimal charged per coin, and the power cost is described as the minting player's power rather than faction power
+
 ### Removed
 - Removed Currencies 1 migration code (`legacy` package and the associated startup migration checks), since servers now run exclusively on Currencies 2
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -11,12 +11,14 @@
 
 ---
 
-### /currency create \<name\>
+### /currency create \<name\> \[--rename|--no-rename\]
 
-**Description:** Create a new currency for your faction.
+**Description:** Create a new currency for your faction. The item held in your main hand is used as the currency's item, so an item must be held when the command is run.
+
+If the held item's display name does not already match the currency name, the command stops and offers a clickable choice rather than creating the currency: **Yes** re-runs the command with `--rename` (the item is renamed to the currency name), and **No** re-runs it with `--no-rename` (the item keeps its own name). Passing either flag directly skips the prompt.
 **Permission:** `currencies.create`
-**Usage:** `/currency create <name>`
-**Example:** `/currency create GoldCoin`
+**Usage:** `/currency create <name> [--rename|--no-rename]`
+**Example:** `/currency create GoldCoin --rename`
 
 ---
 
@@ -29,59 +31,59 @@
 
 ---
 
-### /currency list
+### /currency list \[all|retired|\<faction\>\] \[page\]
 
-**Description:** List all currencies associated with your faction.
+**Description:** List currencies. With no filter, every active currency on the server is listed. `all` lists active and retired currencies, `retired` lists only retired ones, and a faction name or faction ID lists only that faction's currencies. Results are paginated; a trailing page number selects a page (pages are numbered from 1).
 **Permission:** `currencies.list`
-**Usage:** `/currency list`
-**Example:** `/currency list`
+**Usage:** `/currency list [all|retired|<faction>] [page]`
+**Example:** `/currency list retired 2`
 
 ---
 
-### /currency mint \<currency\> \<amount\>
+### /currency mint \<currency\> \[amount\]
 
-**Description:** Mint coins of the specified currency. May cost faction power and/or items depending on server configuration.
+**Description:** Mint coins of the specified currency. May cost the minting player power and/or items depending on server configuration. The amount is optional and defaults to `1` when omitted.
 **Permission:** `currencies.mint`
-**Usage:** `/currency mint <currency> <amount>`
+**Usage:** `/currency mint <currency> [amount]`
 **Example:** `/currency mint GoldCoin 10`
 
 ---
 
-### /currency set name \<currency\> \<new-name\>
+### /currency set name \<currency\> \[new-name\]
 
-**Description:** Set the name of an existing currency. Requires the appropriate faction permission or `currencies.force.rename`.
-**Aliases:** `/currency rename <currency> <new-name>`
+**Description:** Set the name of an existing currency. Requires the appropriate faction permission or `currencies.force.rename`. When the new name is omitted, it is asked for in a chat prompt, which can be exited by typing `cancel`.
+**Aliases:** `/currency rename <currency> [new-name]`
 **Permission:** `currencies.rename`
-**Usage:** `/currency set name <currency> <new-name>`
+**Usage:** `/currency set name <currency> [new-name]`
 **Example:** `/currency set name GoldCoin SilverCoin`
 
 ---
 
-### /currency rename \<currency\> \<new-name\>
+### /currency rename \<currency\> \[new-name\]
 
-**Description:** Alias for `/currency set name`. Rename an existing currency. Requires the appropriate faction permission or `currencies.force.rename`.
+**Description:** Alias for `/currency set name`. Rename an existing currency. Requires the appropriate faction permission or `currencies.force.rename`. When the new name is omitted, it is asked for in a chat prompt, which can be exited by typing `cancel`.
 **Permission:** `currencies.rename`
-**Usage:** `/currency rename <currency> <new-name>`
+**Usage:** `/currency rename <currency> [new-name]`
 **Example:** `/currency rename GoldCoin SilverCoin`
 
 ---
 
-### /currency set description \<currency\> \<description\>
+### /currency set description \<currency\> \[description\]
 
-**Description:** Set or update the description of a currency. Requires the appropriate faction permission or `currencies.force.desc`.
-**Aliases:** `/currency set desc <currency> <description>`
+**Description:** Set or update the description of a currency. Requires the appropriate faction permission or `currencies.force.desc`. When the description is omitted, it is asked for in a chat prompt, which can be exited by typing `cancel`.
+**Aliases:** `/currency set desc <currency> [description]`
 **Permission:** `currencies.desc`
-**Usage:** `/currency set description <currency> <description>`
+**Usage:** `/currency set description <currency> [description]`
 **Example:** `/currency set description GoldCoin "The official coin of the Northern Kingdom"`
 
 ---
 
-### /currency retire \<currency\>
+### /currency retire \<currency\> \[confirm\]
 
-**Description:** Permanently retire a currency so it can no longer be minted.
+**Description:** Permanently retire a currency so it can no longer be minted. Without the trailing `confirm` argument, a clickable confirmation prompt is shown instead of retiring the currency; `confirm` performs the retirement and notifies the owning faction.
 **Permission:** `currencies.retire`
-**Usage:** `/currency retire <currency>`
-**Example:** `/currency retire GoldCoin`
+**Usage:** `/currency retire <currency> [confirm]`
+**Example:** `/currency retire GoldCoin confirm`
 
 ---
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -14,11 +14,11 @@
 ### /currency create \<name\> \[--rename|--no-rename\]
 
 **Description:** Create a new currency for your faction. The item held in your main hand is used as the currency's item, so an item must be held when the command is run.
-
-If the held item's display name does not already match the currency name, the command stops and offers a clickable choice rather than creating the currency: **Yes** re-runs the command with `--rename` (the item is renamed to the currency name), and **No** re-runs it with `--no-rename` (the item keeps its own name). Passing either flag directly skips the prompt.
 **Permission:** `currencies.create`
 **Usage:** `/currency create <name> [--rename|--no-rename]`
 **Example:** `/currency create GoldCoin --rename`
+
+If the held item's display name does not already match the currency name, the command stops and offers a clickable choice rather than creating the currency: **Yes** re-runs the command with `--rename` (the item is renamed to the currency name), and **No** re-runs it with `--no-rename` (the item keeps its own name). Passing either flag directly skips the prompt.
 
 ---
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -71,7 +71,7 @@ coinpurse:
 
 **Type:** boolean
 **Default:** `true`
-**Description:** When `true`, the amount minted is shown to the player after a successful mint operation.
+**Description:** When `true`, `/currency info` includes a `Minted:` line showing the total amount of that currency minted so far. When `false`, the line is omitted.
 
 **Example:**
 ```yaml
@@ -85,7 +85,7 @@ currencies:
 
 **Type:** boolean
 **Default:** `true`
-**Description:** When `true`, minting a currency costs faction power.
+**Description:** When `true`, minting a currency costs the minting player power.
 
 **Example:**
 ```yaml
@@ -97,14 +97,14 @@ currencies:
 
 ## currencies.powerCost
 
-**Type:** integer
+**Type:** decimal
 **Default:** `1`
-**Description:** The amount of faction power deducted per mint operation. Only relevant when `powerCostEnabled` is `true`.
+**Description:** The amount of power deducted from the minting player per coin minted, so minting `n` coins costs `n × powerCost`. Decimal values are supported. Only relevant when `powerCostEnabled` is `true`.
 
 **Example:**
 ```yaml
 currencies:
-  powerCost: 2
+  powerCost: 0.5
 ```
 
 ---
@@ -113,7 +113,7 @@ currencies:
 
 **Type:** boolean
 **Default:** `true`
-**Description:** When `true`, minting a currency requires an item cost (configured per currency).
+**Description:** When `true`, minting consumes one item of the currency's own item type per coin minted. The item type is whatever was held when the currency was created, so the cost is fixed per currency rather than configured here.
 
 **Example:**
 ```yaml

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A Docker-based test server is available for development.
 | Name | Main Contributions |
 |------|---------------------|
 | Daniel Stephenson | Creator |
+| alyphen | Wrote Currencies 2 — the Kotlin rewrite, the jOOQ/Flyway database storage layer, and the coinpurse and currency item systems built on it |
 | Deej | Added the FurnaceHandler |
 | tdlotrring | Fixed a bug with minting costing power even upon failure |
 | Rykurock | Corrected some usage messages and fixed some typos |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -10,23 +10,30 @@
 After installing Currencies and restarting your server:
 
 1. Ensure you are a member of a faction in Medieval Factions.
-2. Use `/currency create <name>` to create a new currency for your faction.
-3. Use `/currency mint <currency> <amount>` to mint coins of your currency.
+2. Hold the item you want to use as the currency's coin, then use `/currency create <name>` to create a new currency for your faction.
+3. Use `/currency mint <currency> [amount]` to mint coins of your currency.
 4. Open your coinpurse with `/coinpurse` to view your current coins.
 
 ## Common Scenarios
 
 ### Creating a Currency
 
-A faction leader or a player with the appropriate faction permission can create a new currency:
+A faction leader or a player with the appropriate faction permission can create a new currency. The item held in the main hand becomes the currency's coin, so an item must be held when the command is run:
 
 ```
 /currency create GoldCoin
 ```
 
+If the held item's display name does not already match the currency name, a **Yes**/**No** prompt is shown instead of creating the currency straight away. **Yes** renames the item to match the currency, and **No** keeps the item's existing name. The prompt can be skipped by passing the choice up front:
+
+```
+/currency create GoldCoin --rename
+/currency create GoldCoin --no-rename
+```
+
 ### Minting Currency
 
-Once a currency exists, authorised faction members can mint coins. Minting costs faction power (configurable) and may require an item cost:
+Once a currency exists, authorised faction members can mint coins. Minting costs the minting player power (configurable) and may require an item cost. The amount defaults to `1` when omitted:
 
 ```
 /currency mint GoldCoin 10
@@ -50,15 +57,24 @@ Inspect the details of a specific currency:
 
 ### Listing Currencies
 
-List all currencies associated with your faction:
+List every active currency on the server:
 
 ```
 /currency list
 ```
 
+The list can be filtered, and a trailing page number selects a page of results:
+
+```
+/currency list all
+/currency list retired
+/currency list MyFaction
+/currency list all 2
+```
+
 ### Renaming a Currency
 
-Rename an existing currency (requires faction permission):
+Rename an existing currency (requires faction permission). Leaving the new name off asks for it in a chat prompt, which can be exited by typing `cancel`:
 
 ```
 /currency rename <currency> <new-name>
@@ -66,7 +82,7 @@ Rename an existing currency (requires faction permission):
 
 ### Setting a Currency Description
 
-Set or update the description of a currency (requires faction permission):
+Set or update the description of a currency (requires faction permission). Leaving the description off asks for it in a chat prompt, which can be exited by typing `cancel`:
 
 ```
 /currency set description <currency> <description>
@@ -74,7 +90,7 @@ Set or update the description of a currency (requires faction permission):
 
 ### Retiring a Currency
 
-Permanently retire a currency so it can no longer be minted (requires faction permission):
+Permanently retire a currency so it can no longer be minted (requires faction permission). A confirmation prompt is shown first; retirement only happens once it is confirmed:
 
 ```
 /currency retire <currency>


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

This is a documentation-only cycle. Issue #190 is resolved, and a repo-wide documentation accuracy sweep was performed: every claim in `COMMANDS.md`, `CONFIG.md`, and `USER_GUIDE.md` was verified against the command and listener sources, and the claims that no longer matched were corrected.

### Attribution (#190)

- `README.md` — alyphen was added to the developers table, credited for Currencies 2 (the Kotlin rewrite, the jOOQ/Flyway storage layer, and the coinpurse and currency item systems built on it). Authorship was confirmed from the commit history: 22 commits, including `c9947e4 Currencies 2.0` (92 files, +2714/−3858).

### Documentation drift corrected

Each correction below was verified against the named source file:

- **`/currency create`** — the held-item requirement and the `--rename` / `--no-rename` flags were undocumented. Both are now described, including the clickable Yes/No prompt shown when the held item's display name does not match the currency name (`CurrencyCreateCommand.kt:43-83`).
- **`/currency list`** — was documented as listing "all currencies associated with your faction" with no arguments. With no filter it actually lists every active currency on the server; `all`, `retired`, and a faction name or ID are accepted filters, and a trailing page number selects a page (`CurrencyListCommand.kt:29-90`).
- **`/currency mint`** — the amount was documented as required. It is optional and defaults to `1` (`CurrencyMintCommand.kt:40-42`).
- **`/currency retire`** — the trailing `confirm` argument and the confirmation prompt shown without it were undocumented (`CurrencyRetireCommand.kt:40-81`).
- **`/currency set name`** and **`/currency set description`** — the new value was documented as required. When it is omitted, a `cancel`-able chat prompt is used instead (`CurrencySetNameCommand.kt:63-68`, `CurrencySetDescriptionCommand.kt:73-78`).
- **`currencies.showAmountMinted`** — was described as showing the amount minted after a successful mint. It actually controls whether `/currency info` includes the `Minted:` total (`CurrencyInfoCommand.kt:31,89-91`).
- **`currencies.powerCost`** — was documented as an integer. It is read with `getDouble` and charged per coin, so `n` coins cost `n × powerCost` (`CurrencyMintCommand.kt:37,69,91`).
- **Power cost wording** — was described as faction power in three places. The cost is deducted from the minting player's own power (`CurrencyMintCommand.kt:70,91`).
- **`currencies.itemCostEnabled`** — the item cost was described as "configured per currency". It consumes one item of the currency's own item type per coin, fixed at creation time rather than configured (`CurrencyMintCommand.kt:77,87`).

`CHANGELOG.md` records both the attribution and the corrections under `[Unreleased]`.

## Findings filed rather than fixed here

Fixing code under a documentation cycle was avoided, so two findings from the sweep were filed as issues instead:

- #199 — the root `/currency` usage message omits the `rename` subcommand, although `rename` is both routed and tab-completed.
- #200 — `CONTRIBUTING.md` and `.github/copilot-instructions.md` instruct contributors to branch from and target `develop`, which does not exist on the remote. The correct resolution depends on the intended branching model, which is a maintainer decision.

## Test plan

- [x] `./gradlew compileKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew test` — BUILD SUCCESSFUL (`NO-SOURCE`; no test sources exist in this repository yet)
- [x] Every documented command signature, permission, flag, and config key re-read against its source file
- [x] `USER_GUIDE.md`'s permissions table re-checked against `src/main/resources/plugin.yml` — all ten permission nodes and defaults match, no changes needed
- [x] `CONFIG.md`'s key list re-checked against `src/main/resources/config.yml` — every documented key exists and every real key is documented
- [ ] Not applicable: no runtime behaviour changed, so no in-game smoke test applies

## Issues deferred this cycle

- #182 (item display names drifting from renamed currencies) — requires a design decision about where and when the correction is applied, which is larger than a documentation-cycle scope.
- #168 (Vault bridge config option) — a new integration touching `build.gradle` and `plugin.yml`, out of scope for a documentation cycle.
- #199, #200 — filed by this cycle; both are code or maintainer-decision changes rather than documentation corrections.

Closes #190

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).
