### PR TITLE
fix: advertise the rename subcommand in the /currency usage message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- Added the project's first unit tests, covering `/currency` subcommand routing and its usage message. The Medieval Factions jar is now also on the test runtime classpath, which mocking the plugin class requires; it remains `compileOnly` for the shaded jar
+
+### Fixed
+- Fixed the `/currency` usage message omitting the `rename` subcommand, which is both routed and tab-completed but was never advertised
+
 ## [3.0.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     implementation 'com.dansplugins:ponder-commands:2.0.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.mockk:mockk:1.13.2'
+    // Declared compileOnly above, but mocking Currencies requires its Medieval Factions
+    // members to be resolvable at test runtime.
+    testImplementation files('lib/medieval-factions-5.5.0.jar')
     jooqGenerator 'org.jooq:jooq-meta-extensions:3.17.4'
 }
 

--- a/src/main/kotlin/com/dansplugins/currencies/command/currency/CurrencyCommand.kt
+++ b/src/main/kotlin/com/dansplugins/currencies/command/currency/CurrencyCommand.kt
@@ -47,7 +47,7 @@ class CurrencyCommand(private val plugin: Currencies) : CommandExecutor, TabComp
             "mint" -> mintCommand.onCommand(sender, command, label, args.drop(1).toTypedArray())
             "retire" -> retireCommand.onCommand(sender, command, label, args.drop(1).toTypedArray())
             else -> {
-                sender.sendMessage("${RED}Usage: /currency [balance|create|info|set|list|mint|retire]")
+                sender.sendMessage("${RED}Usage: /currency [balance|create|info|set|rename|list|mint|retire]")
                 true
             }
         }

--- a/src/test/kotlin/com/dansplugins/currencies/command/currency/CurrencyCommandTest.kt
+++ b/src/test/kotlin/com/dansplugins/currencies/command/currency/CurrencyCommandTest.kt
@@ -27,11 +27,12 @@ class CurrencyCommandTest {
     }
 
     @Test
-    fun `usage message advertises every routed subcommand`() {
-        assertEquals(
-            listOf("${RED}Usage: /currency [balance|create|info|set|rename|list|mint|retire]"),
-            messagesSentBy("notasubcommand")
-        )
+    fun `usage message advertises every subcommand offered by tab completion`() {
+        val subcommands = currencyCommand.onTabComplete(mockk(relaxed = true), bukkitCommand, "currency", emptyArray())
+        val usage = messagesSentBy("notasubcommand").single()
+        subcommands.forEach { subcommand ->
+            assertTrue(usage.contains(subcommand), "Usage message does not advertise '$subcommand': $usage")
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/dansplugins/currencies/command/currency/CurrencyCommandTest.kt
+++ b/src/test/kotlin/com/dansplugins/currencies/command/currency/CurrencyCommandTest.kt
@@ -1,0 +1,52 @@
+package com.dansplugins.currencies.command.currency
+
+import com.dansplugins.currencies.Currencies
+import io.mockk.every
+import io.mockk.mockk
+import org.bukkit.ChatColor.RED
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CurrencyCommandTest {
+
+    private val plugin = mockk<Currencies>(relaxed = true) {
+        every { name } returns "currencies"
+    }
+    private val bukkitCommand = mockk<Command>(relaxed = true)
+    private val currencyCommand = CurrencyCommand(plugin)
+
+    private fun messagesSentBy(vararg args: String): List<String> {
+        val messages = mutableListOf<String>()
+        val sender = mockk<CommandSender>(relaxed = true)
+        every { sender.sendMessage(capture(messages)) } returns Unit
+        assertTrue(currencyCommand.onCommand(sender, bukkitCommand, "currency", args))
+        return messages
+    }
+
+    @Test
+    fun `usage message advertises every routed subcommand`() {
+        assertEquals(
+            listOf("${RED}Usage: /currency [balance|create|info|set|rename|list|mint|retire]"),
+            messagesSentBy("notasubcommand")
+        )
+    }
+
+    @Test
+    fun `usage message is sent when no subcommand is given`() {
+        assertEquals(
+            listOf("${RED}Usage: /currency [balance|create|info|set|rename|list|mint|retire]"),
+            messagesSentBy()
+        )
+    }
+
+    @Test
+    fun `rename is routed to the set name command rather than falling back to usage`() {
+        assertEquals(
+            listOf("${RED}You do not have permission to rename currencies."),
+            messagesSentBy("rename", "GoldCoin", "SilverCoin")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- The root `/currency` fallback usage message listed seven of the eight subcommands the router dispatches, omitting `rename`. `rename` is present in both the `when` block that routes execution and the `subcommands` list used for tab completion, so the subcommand worked but was never advertised. The usage string is now `/currency [balance|create|info|set|rename|list|mint|retire]`.
- The project's first unit tests are added alongside the fix. `CurrencyCommandTest` covers the usage message (with and without an argument) and confirms that `rename` is routed to the set-name command rather than falling through to the usage branch.
- `lib/medieval-factions-5.5.0.jar` is added to `testImplementation`. It was previously `compileOnly`, so mocking the `Currencies` plugin class failed at test runtime with `NoClassDefFoundError: com/dansplugins/factionsystem/MedievalFactions`. It remains `compileOnly` for compilation and packaging.

## Test plan

- [x] `./gradlew clean build` passes (compile + 3 tests).
- [x] Regression evidence gathered empirically: with the one-line fix stashed, the two usage-message tests **FAIL**; with it restored, all three **PASS**.
- [x] The shaded artifact was checked for leakage of the new test-only dependency. `build/libs/currencies-3.0.0-SNAPSHOT-8-8-2026-all.jar` contains 88 entries and none of `com/dansplugins/factionsystem/MedievalFactions`, `io/mockk`, or `org/junit` — `testImplementation` does not feed `runtimeClasspath`, so the release artifact is unchanged.
- [x] Documentation was re-verified against source: `COMMANDS.md` already documents `/currency rename` and `/currency set name`, `USER_GUIDE.md`'s permissions table matches `plugin.yml`, and every key in `CONFIG.md` matches `src/main/resources/config.yml`. Only the in-game usage string was inaccurate, and a `[Unreleased]` CHANGELOG section records both changes.

## Merge note

`build.gradle` is on this loop's do-not-auto-merge list, because dependency changes can affect the shaded JAR and the release artifact. The check above shows this particular change does not, but the hold is path-based rather than judgment-based, so this PR is being left for maintainer approval rather than merged autonomously.

## Deferred issues

The rest of the open backlog was not picked up this cycle:

- #200 (`develop` branch references in `CONTRIBUTING.md` and `.github/copilot-instructions.md`) — deferred: the correct resolution depends on which branching model the project intends to use, which is a maintainer decision, and `.github/copilot-instructions.md` is agent-loaded configuration that is left untouched without explicit direction. Note that `.github/workflows/build.yml` also triggers on `develop` and should be included in whatever resolution is chosen.
- #182 (item display names drifting from renamed currencies) — deferred: the issue explicitly asks for a design decision on the correction mechanism, which exceeds a polish-sized PR.
- #168 (Vault bridge in config) — deferred: a feature-sized integration, out of scope for this cycle.

Closes #199

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_