### PR TITLE
test: cover /currency set routing and /currency balance reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added the project's first unit tests, covering `/currency` subcommand routing and its usage message. The Medieval Factions jar is now also on the test runtime classpath, which mocking the plugin class requires; it remains `compileOnly` for the shaded jar
+- Extended the unit tests to `/currency set` routing and tab completion, and to `/currency balance`, whose report is built on the scheduler's async thread and is now exercised by capturing and running the scheduled task
 - A `Dev Release` workflow, which republishes a rolling `dev` prerelease of `main` on every non-documentation push. This is what Dan's Plugin Manager's experimental channel installs from: `/dpm get currencies --experimental` reads `releases/tags/dev`, so without it there is nothing for that command to download. The prerelease is unreleased, unreviewed code and is marked as such.
 
 ### Fixed

--- a/src/test/kotlin/com/dansplugins/currencies/command/currency/balance/CurrencyBalanceCommandTest.kt
+++ b/src/test/kotlin/com/dansplugins/currencies/command/currency/balance/CurrencyBalanceCommandTest.kt
@@ -1,0 +1,116 @@
+package com.dansplugins.currencies.command.currency.balance
+
+import com.dansplugins.currencies.Currencies
+import com.dansplugins.currencies.balance.Balance
+import com.dansplugins.currencies.currency.Currency
+import com.dansplugins.currencies.currency.CurrencyId
+import com.dansplugins.currencies.currency.CurrencyStatus.RETIRED
+import com.dansplugins.factionsystem.faction.MfFactionId
+import com.dansplugins.factionsystem.player.MfPlayerId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.bukkit.ChatColor.AQUA
+import org.bukkit.ChatColor.GRAY
+import org.bukkit.ChatColor.RED
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CurrencyBalanceCommandTest {
+
+    private val gold = Currency(id = CurrencyId("gold"), factionId = MfFactionId("faction"), name = "Gold", item = mockk(relaxed = true))
+    private val silver = Currency(id = CurrencyId("silver"), factionId = MfFactionId("faction"), name = "Silver", item = mockk(relaxed = true), status = RETIRED)
+    private val bronze = Currency(id = CurrencyId("bronze"), factionId = MfFactionId("faction"), name = "Bronze", item = mockk(relaxed = true))
+
+    private val plugin = mockk<Currencies>(relaxed = true) {
+        every { name } returns "currencies"
+    }
+    private val bukkitCommand = mockk<Command>(relaxed = true)
+    private val balanceCommand = CurrencyBalanceCommand(plugin)
+
+    private fun player(permitted: Boolean) = mockk<Player>(relaxed = true) {
+        every { hasPermission("currencies.balance") } returns permitted
+        every { uniqueId } returns UUID.randomUUID()
+    }
+
+    private fun messagesSentBy(sender: CommandSender): List<String> {
+        val messages = mutableListOf<String>()
+        every { sender.sendMessage(capture(messages)) } returns Unit
+        assertTrue(balanceCommand.onCommand(sender, bukkitCommand, "balance", emptyArray()))
+        return messages
+    }
+
+    /**
+     * The balance report is built on the scheduler's async thread, so the scheduled task is captured
+     * and run here rather than only asserting that something was scheduled.
+     */
+    private fun balanceReportFor(sender: Player, currencies: List<Currency>, balances: List<Balance>): List<String> {
+        every { plugin.services.currencyService.currencies } returns currencies
+        every { plugin.services.balanceService.getBalances(any()) } returns balances
+        val task = slot<Runnable>()
+        every { plugin.server.scheduler.runTaskAsynchronously(plugin, capture(task)) } returns mockk(relaxed = true)
+        val messages = messagesSentBy(sender)
+        task.captured.run()
+        return messages
+    }
+
+    @Test
+    fun `senders without the balance permission are refused`() {
+        assertEquals(
+            listOf("${RED}You do not have permission to view your balance."),
+            messagesSentBy(player(permitted = false))
+        )
+    }
+
+    @Test
+    fun `non-players are refused even when permitted`() {
+        val console = mockk<CommandSender>(relaxed = true) {
+            every { hasPermission("currencies.balance") } returns true
+        }
+        assertEquals(
+            listOf("${RED}You must be a player to use this command."),
+            messagesSentBy(console)
+        )
+    }
+
+    @Test
+    fun `every currency on the server is reported, including ones the player holds none of`() {
+        val sender = player(permitted = true)
+        val balances = listOf(Balance(MfPlayerId.fromBukkitPlayer(sender), gold.id, balance = 42))
+        assertEquals(
+            listOf(
+                "${AQUA}=== Coinpurse Contents ===",
+                "${GRAY}Gold: 42",
+                "${GRAY}Bronze: 0"
+            ),
+            balanceReportFor(sender, listOf(gold, bronze), balances)
+        )
+    }
+
+    @Test
+    fun `retired currencies are reported with a retired marker`() {
+        val sender = player(permitted = true)
+        val balances = listOf(Balance(MfPlayerId.fromBukkitPlayer(sender), silver.id, balance = 7))
+        assertEquals(
+            listOf(
+                "${AQUA}=== Coinpurse Contents ===",
+                "${GRAY}Silver: 7 ${RED}[retired]"
+            ),
+            balanceReportFor(sender, listOf(silver), balances)
+        )
+    }
+
+    @Test
+    fun `only the header is reported when the server has no currencies`() {
+        val sender = player(permitted = true)
+        assertEquals(
+            listOf("${AQUA}=== Coinpurse Contents ==="),
+            balanceReportFor(sender, emptyList(), emptyList())
+        )
+    }
+}

--- a/src/test/kotlin/com/dansplugins/currencies/command/currency/set/CurrencySetCommandTest.kt
+++ b/src/test/kotlin/com/dansplugins/currencies/command/currency/set/CurrencySetCommandTest.kt
@@ -68,7 +68,7 @@ class CurrencySetCommandTest {
     @Test
     fun `desc is an alias of description`() {
         assertEquals(
-            messagesSentBy("description", "Gold", "Shiny"),
+            listOf("${RED}You do not have permission to change the description of currencies."),
             messagesSentBy("desc", "Gold", "Shiny")
         )
     }

--- a/src/test/kotlin/com/dansplugins/currencies/command/currency/set/CurrencySetCommandTest.kt
+++ b/src/test/kotlin/com/dansplugins/currencies/command/currency/set/CurrencySetCommandTest.kt
@@ -1,0 +1,105 @@
+package com.dansplugins.currencies.command.currency.set
+
+import com.dansplugins.currencies.Currencies
+import com.dansplugins.currencies.currency.Currency
+import com.dansplugins.factionsystem.faction.MfFactionId
+import io.mockk.every
+import io.mockk.mockk
+import org.bukkit.ChatColor.RED
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CurrencySetCommandTest {
+
+    private val gold = Currency(factionId = MfFactionId("faction"), name = "Gold", item = mockk(relaxed = true))
+    private val plugin = mockk<Currencies>(relaxed = true) {
+        every { name } returns "currencies"
+        every { services.currencyService.currencies } returns listOf(gold)
+    }
+    private val bukkitCommand = mockk<Command>(relaxed = true)
+    private val setCommand = CurrencySetCommand(plugin)
+
+    private fun messagesSentBy(vararg args: String): List<String> {
+        val messages = mutableListOf<String>()
+        val sender = mockk<CommandSender>(relaxed = true)
+        every { sender.sendMessage(capture(messages)) } returns Unit
+        assertTrue(setCommand.onCommand(sender, bukkitCommand, "currency", args))
+        return messages
+    }
+
+    private fun tabCompletionFor(vararg args: String) =
+        setCommand.onTabComplete(mockk(relaxed = true), bukkitCommand, "currency", args)
+
+    @Test
+    fun `usage message is sent when no subcommand is given`() {
+        assertEquals(
+            listOf("${RED}Usage: /currency set [name|desc]"),
+            messagesSentBy()
+        )
+    }
+
+    @Test
+    fun `usage message is sent when the subcommand is not recognised`() {
+        assertEquals(
+            listOf("${RED}Usage: /currency set [name|desc]"),
+            messagesSentBy("notasubcommand")
+        )
+    }
+
+    @Test
+    fun `name is routed to the set name command`() {
+        assertEquals(
+            listOf("${RED}You do not have permission to rename currencies."),
+            messagesSentBy("name", "Gold", "Silver")
+        )
+    }
+
+    @Test
+    fun `description is routed to the set description command`() {
+        assertEquals(
+            listOf("${RED}You do not have permission to change the description of currencies."),
+            messagesSentBy("description", "Gold", "Shiny")
+        )
+    }
+
+    @Test
+    fun `desc is an alias of description`() {
+        assertEquals(
+            messagesSentBy("description", "Gold", "Shiny"),
+            messagesSentBy("desc", "Gold", "Shiny")
+        )
+    }
+
+    @Test
+    fun `subcommands are matched regardless of case`() {
+        assertEquals(
+            listOf("${RED}You do not have permission to rename currencies."),
+            messagesSentBy("NAME", "Gold", "Silver")
+        )
+    }
+
+    @Test
+    fun `every advertised subcommand is offered by tab completion`() {
+        assertEquals(listOf("name", "description", "desc"), tabCompletionFor())
+    }
+
+    @Test
+    fun `tab completion filters the subcommands by the partial argument`() {
+        assertEquals(listOf("description", "desc"), tabCompletionFor("d"))
+        assertEquals(listOf("name"), tabCompletionFor("n"))
+    }
+
+    @Test
+    fun `tab completion of later arguments is delegated to the routed subcommand`() {
+        assertEquals(listOf("Gold"), tabCompletionFor("name", "Go"))
+        assertEquals(listOf("Gold"), tabCompletionFor("desc", "Go"))
+    }
+
+    @Test
+    fun `tab completion of later arguments is empty when the subcommand is not recognised`() {
+        assertEquals(emptyList<String>(), tabCompletionFor("notasubcommand", "Go"))
+    }
+}


### PR DESCRIPTION
## Summary

- Tests were added for `CurrencySetCommand`, covering the routing of `name`, `description` and its `desc` alias, case-insensitive subcommand matching, the fallback usage message, and tab completion (the advertised subcommand list, prefix filtering, and delegation of later arguments to the routed subcommand).
- Tests were added for `CurrencyBalanceCommand`, covering the `currencies.balance` permission guard, the player-only guard, and the balance report itself: the header, one line per currency on the server, the `0` default for a currency the player holds none of, and the `[retired]` marker.
- The balance report is assembled inside a task handed to `BukkitScheduler.runTaskAsynchronously`, so the scheduled `Runnable` is captured and run by the test rather than the test merely asserting that a task was scheduled.
- No production code was changed. These are characterization tests asserting the behaviour that exists today.

## Why this work

No tracking issue — this cycle was devoted to unit-test expansion. The open backlog is currently gated on maintainer decisions (see below), so coverage was extended instead of speculative feature work.

## Deferred issues and why

- **#204** (`plugin.yml` lists two of eight subcommands) — the issue itself asks for a maintainer preference to be settled first (full list inline versus a pointer to `COMMANDS.md`), and `src/main/resources/plugin.yml` is on this loop's do-not-auto-merge list.
- **#200** (`develop` branch references) — the correct fix depends on which branching model the project intends to use, and one of the two affected files is agent-loaded configuration.
- **#182** (item display names drifting from a renamed currency) — feature-scale work needing a design decision on how the correction is triggered.
- **#168** (Vault bridge) — feature-scale work, larger than a polish-sized PR.

## Test plan

- [x] `./gradlew test` — 18 tests, 0 failures (3 pre-existing, 15 new)
- [x] The new tests were confirmed to be load-bearing by mutation: with `?.balance ?: 0` changed to `?: 99` in `CurrencyBalanceCommand` and `desc` removed from `CurrencySetCommand`'s subcommand list, 3 of the new tests fail; both mutations were reverted
- [x] No real database or network access is used — collaborators are mocked with MockK, matching `CurrencyCommandTest`
- [x] `CHANGELOG.md` `[Unreleased]` updated

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_