### PR TITLE
fix: bundle Ponder instead of borrowing it from Medieval Factions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation 'com.zaxxer:HikariCP:5.0.1'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'org.slf4j:slf4j-api:1.8.0-beta4'
-    implementation 'com.dansplugins:ponder-bukkit:2.0.0'
     implementation 'com.dansplugins:ponder-commands:2.0.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.mockk:mockk:1.13.2'
@@ -118,7 +117,12 @@ processResources {
 shadowJar {
     mergeServiceFiles()
     dependencies {
-        exclude(dependency("::"))
+        // Everything else is deliberately not bundled: Medieval Factions already
+        // shades those libraries and Currencies borrows them at runtime. Ponder is
+        // the exception — no Medieval Factions build ships it, so relocating into
+        // MF's namespace pointed at classes that were never there. Bundle it here.
+        include(dependency('com.dansplugins:ponder-bukkit'))
+        include(dependency('com.dansplugins:ponder-commands'))
     }
 
     // Exclude the medieval-factions jar file specifically
@@ -140,7 +144,7 @@ shadowJar {
     relocate 'org.jetbrains', 'com.dansplugins.factionsystem.shadow.org.jetbrains'
     relocate 'org.jooq', 'com.dansplugins.factionsystem.shadow.org.jooq'
     relocate 'org.reactivestreams', 'com.dansplugins.factionsystem.shadow.org.reactivestreams'
-    relocate 'preponderous.ponder', 'com.dansplugins.factionsystem.shadow.preponderous.ponder'
+    relocate 'preponderous.ponder', 'com.dansplugins.currencies.shadow.preponderous.ponder'
 }
 
 artifacts {


### PR DESCRIPTION
Fixes #208.

## The problem

`shadowJar` excluded every dependency from the jar and relocated `preponderous.ponder` into **Medieval Factions'** shadow namespace, so those classes had to be provided by MF at runtime. They never are:

| Jar | Classes under `preponderous` |
|---|---|
| MedievalFactions 6.0.0-SNAPSHOT-7-25-2026 (`dev`) | 0 |
| MedievalFactions 5.9.0 (stable) | 0 |
| `lib/medieval-factions-5.5.0.jar` | 0 |

MF 5.9.0's shadow roots are `com, dev, io, jakarta, kotlin, org` — there is no `preponderous` root, so this is not a 6.0.0 regression. The result was:

```
NoClassDefFoundError: com/dansplugins/factionsystem/shadow/preponderous/ponder/minecraft/bukkit/plugin/PluginsKt
	at com.dansplugins.currencies.Currencies.onEnable(Currencies.kt:142)
```

## The change

```groovy
dependencies {
    include(dependency('com.dansplugins:ponder-bukkit'))
    include(dependency('com.dansplugins:ponder-commands'))
}
relocate 'preponderous.ponder', 'com.dansplugins.currencies.shadow.preponderous.ponder'
```

Ponder is the one library on the dependency list that MF does not shade, so it is the one that cannot be borrowed. Everything else is untouched — **h2, HikariCP, jOOQ, Flyway and the Kotlin stdlib are still excluded** and still come from MF at runtime, which is the arrangement this build was designed around.

No source changes: the `preponderous.ponder` imports stay as they are, the relocation simply now points at classes that exist.

## Verification

Built with `./gradlew shadowJar`, then inspected the jar:

- 13 Ponder classes bundled, all under `com/dansplugins/currencies/shadow/preponderous/ponder/` — including `PluginsKt` (the missing one) and `ArgsKt` (`unquote`)
- **0** classes reference `factionsystem/shadow/preponderous`; 17 reference the new namespace
- `org/h2/`, `com/zaxxer/`, `org/jooq/`, `org/flywaydb/`, `kotlin/` → 0 classes each, confirming nothing was over-bundled
- Jar grows 118 KB → 182 KB

`./gradlew test` — 18 tests, 0 failures.

**Runtime**: deployed to a live Spigot 26.1.2 server running Medieval Factions on the `dev` channel. Currencies enables cleanly, `/currency help` responds, and the server reports 0 plugin enable failures across all 16 plugins — previously Currencies was the only one failing.

Built under JDK 11 (Gradle 7.4.2 does not run on JDK 21); the Kotlin toolchain still targeted 17 as configured.

---

_drafted by Claude on behalf of dmccoystephenson_